### PR TITLE
provide #%top-interaction so that drracket knows the REPL is available

### DIFF
--- a/lang/empty.rkt
+++ b/lang/empty.rkt
@@ -1,4 +1,5 @@
 #lang racket/base
+(provide #%top-interaction)
 (require "lang.rkt")
 ;; Since `compile-program` generates syntax that already
 ;; includes binding, avoid exporting anything from the


### PR DESCRIPTION
Given that providing `#%module-begin` causes an ambitious binding error, I suppose this could too if `compile-program` or `compile-statement` ever inserted one, but they don't seem to and I can't see why they would want to.