### PR TITLE
Make unbound logic variables hygienic

### DIFF
--- a/tests/unit.rkt
+++ b/tests/unit.rkt
@@ -259,6 +259,8 @@
  ; Unit tests
  (logic-var? (_))
  
+ (%which (x) (%= x '_) (%= x 'foo)) => #f
+ 
  (%which () (%/= 1 1)) => #f
  (%which () (%/= 1 2)) => empty
  (%more) => #f

--- a/unify.rkt
+++ b/unify.rkt
@@ -85,7 +85,7 @@
             ((apply pred args) fk)
             (fk 'fail))))))
 
-(define *unbound* '_)
+(define *unbound* (string->uninterned-symbol "_"))
 
 ;;unbound refs point to themselves
 (define (make-ref [val *unbound*])
@@ -153,8 +153,9 @@
   (uni-match 
    v
    [(? logic-var? s)
-    (if (frozen-logic-var? s) s
-        (logic-var-val* (logic-var-val s)))]
+    (cond [(unbound-logic-var? s) '_]
+          [(frozen-logic-var? s) s]
+          [else (logic-var-val* (logic-var-val s))])]
    [(cons l r)
     (cons (logic-var-val* l) (logic-var-val* r))]
    [(mcons l r)


### PR DESCRIPTION
Allow logic variables to be bound to the symbol `_`.

This will of course break code that uses `'_` to mean `(_)`, but since that's contrary to the documentation I wonder if that's acceptable?