### PR TITLE
Fix unwind with cut

### DIFF
--- a/racklog.rkt
+++ b/racklog.rkt
@@ -75,8 +75,9 @@
     ((%cut-delimiter g)
      (lambda (__fk)
        (let ((this-! (lambda (__fk2)
-                       (__fk2 'unwind-trail)
-                       __fk)))
+                       (lambda (msg)
+                         (__fk2 'unwind-trail)
+                         (__fk msg)))))
          (syntax-parameterize 
           ([! (make-rename-transformer #'this-!)])
           ((logic-var-val* g) __fk)))))))
@@ -97,10 +98,9 @@
                     fail-case))
                  (define this-! 
                    (lambda (fk1) 
-                     (λ (fk2)
-                       ;; XXX could be (fail-unify 'unwind-trail)
-                       (unify-cleanup)
-                       (fail-relation 'fail))))
+                     (lambda (msg)
+                       (fk1 'unwind-trail)
+                       (fail-relation msg))))
                  (syntax-parameterize 
                      ([! (make-rename-transformer #'this-!)])
                    (__sk 

--- a/tests/unit.rkt
+++ b/tests/unit.rkt
@@ -451,6 +451,24 @@
  (%which () (%cut-delimiter (%or (%and ! %true) %true))) => empty
  (%more) => #f
  
+ (%which (x) (%not (%= x 1))) => #f
+ (%which (x) (%or (%not (%= x 1)) %true)) => `([x . _])
+ (%more) => #f
+ (%which (x) (%not (%not (%= x 1)))) => `([x . _])
+ (%more) => #f
+ (%which (x) (%if-then-else (%= x 1) %true %fail)) => `([x . 1])
+ (%more) => #f
+ (%which (x) (%if-then-else (%and (%= x 1) (%= x 2)) %true %true)) => `([x . _])
+ (%more) => #f
+ (%which (x) (%cut-delimiter (%and (%= x 1) !))) => `([x . 1])
+ (%more) => #f
+ (let ([r (%rel (x) [(x) (%= x 1) !])]) (%which (x) (%or (r x) %true))) => `([x . 1])
+ (%more) => `([x . _])
+ (%more) => #f
+ (%which (x) (%or ((%rel () [() (%= x 1) !])) %true)) => `([x . 1])
+ (%more) => `([x . _])
+ (%more) => #f
+ 
  (%which () (%empty-rel 1 1)) => #f
  
  (%which () %fail) => #f


### PR DESCRIPTION
This clears up the problems in issue #10.

- `%cut-delimiter` was unwinding too soon; fix is to wrap a lambda around the cut FK.
- `%rel` was not unwinding enough; fix is to unwind bindings in the body in the cut FK.
- Added a load of unit tests to verify expected behavior.