### PR TITLE
Fix unwind past let/racklog-fk

### DIFF
--- a/tests/unit.rkt
+++ b/tests/unit.rkt
@@ -469,6 +469,26 @@
  (%more) => `([x . _])
  (%more) => #f
  
+ (%which (x y)
+   (%or (%= x 1) (%= x 2))
+   (%cut-delimiter (%and (%or (%= x 2) (%= y 'foo))
+                         (%or %true)
+                         !)))
+ => `([x . 1] [y . foo])
+ (%more) => `([x . 2] [y . _])
+ (%more) => #f
+ 
+ (%which (x y)
+   (%or (%= x 1) (%= x 2))
+   (%cut-delimiter (%and (%or (%= x 2) (%= y 'foo))
+                         ((%rel () [()]))
+                         !)))
+ => `([x . 1] [y . foo])
+ (%more) => `([x . 2] [y . _])
+ (%more) => #f
+ 
+ (%which (x) (%or (%cut-delimiter (%and (%= x 1) (%cut-delimiter %true) ! %fail)) %true)) => `([x . _])
+ 
  (%which () (%empty-rel 1 1)) => #f
  
  (%which () %fail) => #f

--- a/unify.rkt
+++ b/unify.rkt
@@ -456,9 +456,9 @@
     (define (cleanup-n-fail s)
       (cleanup s)
       (fk 'fail))
-    (define (unwind-trail s)
+    (define (unwind-trail s d)
       (cleanup s)
-      (fk 'unwind-trail))
+      (fk d))
     (define (unify1 t1 t2 s)
       (cond [(eqv? t1 t2) s]
             [(logic-var? t1)
@@ -521,8 +521,7 @@
     (values
      (λ () (cleanup s))
      (lambda (d)
-       ((if (eq? d 'unwind-trail) unwind-trail cleanup-n-fail)
-        s)))))
+       (if (procedure? d) (unwind-trail s d) (cleanup-n-fail s))))))
 
 (define-syntax-rule (or* x f ...)
   (or (f x) ...))


### PR DESCRIPTION
Two problems fixed here:

First, `make-racklog-fk` didn't pass on unwind messages, so unwinding stopped at the first `let/racklog-fk` (used in `%or` and `%rel`). The fix is to pass an additional parameter (an "unwind FK") which should be used for unwinding (this is different from the failure FK when there are skipped clauses).

Second, `%cut-delimiter` and `%rel` did not stop unwinding (due to the first problem it usually stopped at about the right place by chance). The fix is to pass the "stop unwinding here" FK as the message instead of the symbol `'unwind-trail`.