### PR TITLE
Fix some more unwind edge cases and refactor %rel

### DIFF
--- a/racklog.rkt
+++ b/racklog.rkt
@@ -86,28 +86,12 @@
   (syntax-rules ()
     ((%rel (v ...) ((a ...) subgoal ...) ...)
      (lambda __fmls
-       (lambda (fail-relation)
-         (let/racklog-sk 
-          __sk
-          (%let (v ...)
-                (let/racklog-fk 
-                 (fail-case fail-relation)
-                 (define-values
-                   (unify-cleanup fail-unify)
-                   ((inner-unify __fmls (list a ...))
-                    fail-case))
-                 (define this-! 
-                   (lambda (fk1) 
-                     (lambda (msg)
-                       (and (not (equal? fk1 fail-relation)) (fk1 fail-relation))
-                       (and (not (equal? fail-relation msg)) (fail-relation msg)))))
-                 (syntax-parameterize 
-                     ([! (make-rename-transformer #'this-!)])
-                   (__sk 
-                    ((%and subgoal ...) 
-                     fail-unify))))
-                ...
-                (fail-relation 'fail))))))))
+       (%let (v ...)
+         (%cut-delimiter
+           (%or
+             (%and (%= __fmls (list a ...))
+                   subgoal ...)
+             ...)))))))
 
 (define %fail
   (lambda (fk) (fk 'fail)))

--- a/racklog.rkt
+++ b/racklog.rkt
@@ -76,7 +76,7 @@
      (lambda (__fk)
        (let ((this-! (lambda (__fk2)
                        (lambda (msg)
-                         (__fk2 __fk)
+                         (and (not (equal? __fk2 __fk)) (__fk2 __fk))
                          (__fk msg)))))
          (syntax-parameterize 
           ([! (make-rename-transformer #'this-!)])
@@ -99,7 +99,7 @@
                  (define this-! 
                    (lambda (fk1) 
                      (lambda (msg)
-                       (fk1 fail-relation)
+                       (and (not (equal? fk1 fail-relation)) (fk1 fail-relation))
                        (fail-relation msg))))
                  (syntax-parameterize 
                      ([! (make-rename-transformer #'this-!)])
@@ -376,7 +376,7 @@
   (λ (msg)
     (if (not (procedure? msg))
       (fk 'fail)
-      (and uk (not (eq? uk msg)) (uk msg)))))
+      (and uk (not (equal? uk msg)) (uk msg)))))
 (define-syntax-rule (let/racklog-fk (k uk) e ...)
   (let/racklog-cc fk (let ([k (make-racklog-fk fk uk)]) e ...)))
 

--- a/racklog.rkt
+++ b/racklog.rkt
@@ -77,7 +77,7 @@
        (let ((this-! (lambda (__fk2)
                        (lambda (msg)
                          (and (not (equal? __fk2 __fk)) (__fk2 __fk))
-                         (__fk msg)))))
+                         (and (not (equal? __fk msg)) (__fk msg))))))
          (syntax-parameterize 
           ([! (make-rename-transformer #'this-!)])
           ((logic-var-val* g) __fk)))))))
@@ -100,7 +100,7 @@
                    (lambda (fk1) 
                      (lambda (msg)
                        (and (not (equal? fk1 fail-relation)) (fk1 fail-relation))
-                       (fail-relation msg))))
+                       (and (not (equal? fail-relation msg)) (fail-relation msg)))))
                  (syntax-parameterize 
                      ([! (make-rename-transformer #'this-!)])
                    (__sk 

--- a/tests/unit.rkt
+++ b/tests/unit.rkt
@@ -477,6 +477,12 @@
  (%which (x) (%= x 1) (%or ((%rel () [() !])) %true)) => `([x . 1])
  (%more) => `([x . 1])
  (%more) => #f
+ (%which (x) (%= x 1) (%or (%cut-delimiter (%and ! !)) %true)) => `([x . 1])
+ (%more) => `([x . 1])
+ (%more) => #f
+ (%which (x) (%= x 1) (%or ((%rel () [() ! !])) %true)) => `([x . 1])
+ (%more) => `([x . 1])
+ (%more) => #f
  
  (%which (x y)
    (%or (%= x 1) (%= x 2))

--- a/tests/unit.rkt
+++ b/tests/unit.rkt
@@ -468,6 +468,15 @@
  (%which (x) (%or ((%rel () [() (%= x 1) !])) %true)) => `([x . 1])
  (%more) => `([x . _])
  (%more) => #f
+ (%which (x y) (%= x 1) (%or (%cut-delimiter (%and (%= y 2) !)) %true)) => `([x . 1] [y . 2])
+ (%more) => `([x . 1] [y . _])
+ (%more) => #f
+ (%which (x) (%= x 1) (%or (%cut-delimiter !) %true)) => `([x . 1])
+ (%more) => `([x . 1])
+ (%more) => #f
+ (%which (x) (%= x 1) (%or ((%rel () [() !])) %true)) => `([x . 1])
+ (%more) => `([x . 1])
+ (%more) => #f
  
  (%which (x y)
    (%or (%= x 1) (%= x 2))

--- a/unify.rkt
+++ b/unify.rkt
@@ -520,7 +520,7 @@
      (lambda (d)
        (cleanup s)
        (if (procedure? d)
-           (and (not (equal? fk d)) (fk d))
+           (unless (equal? fk d) (fk d)) ; unwind
            (fk 'fail))))))
 
 (define-syntax-rule (or* x f ...)

--- a/unify.rkt
+++ b/unify.rkt
@@ -456,9 +456,6 @@
     (define (cleanup-n-fail s)
       (cleanup s)
       (fk 'fail))
-    (define (unwind-trail s d)
-      (cleanup s)
-      (fk d))
     (define (unify1 t1 t2 s)
       (cond [(eqv? t1 t2) s]
             [(logic-var? t1)
@@ -521,7 +518,10 @@
     (values
      (λ () (cleanup s))
      (lambda (d)
-       (if (procedure? d) (unwind-trail s d) (cleanup-n-fail s))))))
+       (cleanup s)
+       (if (procedure? d)
+           (and (not (equal? fk d)) (fk d))
+           (fk 'fail))))))
 
 (define-syntax-rule (or* x f ...)
   (or (f x) ...))


### PR DESCRIPTION
I'm happy to split this into separate PRs if you prefer.

- Add more checks when unwinding to make sure we stop at the right place (fixes double cut; and cut or unification as first goal in cut delimiter)
- Use `equal?` instead of `eq?` to check stop point (fixes unification as first goal; presumably due to chaperones being introduced when passing procedures between modules)
- Refactor `%rel` to use other primitives to save having to fix the same problems in two places