### PR TITLE
Combine %rel clauses into a list

### DIFF
--- a/tests/unit.rkt
+++ b/tests/unit.rkt
@@ -597,6 +597,14 @@
  (let ([rel (%rel () [(1) !] [(1) (%repeat)])])
    (test (%which () (rel 1)) => empty
          (%more) => #f))
+ (let ([rel (%rel () [(2)])])
+   (%assert-after! rel () [(1) !])
+   (test (%which (x) (rel x)) => `([x . 1])
+         (%more) => #f))
+ (let ([rel (%rel () [(1) !])])
+   (%assert! rel () [(2)])
+   (test (%which (x) (rel x)) => `([x . 1])
+         (%more) => #f))
  
  (local [(define (many-%more n)
            (if (zero? n)


### PR DESCRIPTION
This fixes cuts in cases where %assert! and %assert-after! are used. My interpretation of the documentation is that a cut in a relation should skip _all_ following clauses, including any introduced by assertions (and vice versa for assert-after).

As before, the relation itself is not mutated - only the identifier is reassigned.

As a bonus, this makes relations significantly faster.