### PR TITLE
Store logic variable values in continuation marks

### DIFF
--- a/control.rkt
+++ b/control.rkt
@@ -1,0 +1,5 @@
+#lang racket/base
+(require)
+(provide (all-defined-out))
+
+(define racklog-prompt-tag (make-continuation-prompt-tag 'racklog))

--- a/racklog.rkt
+++ b/racklog.rkt
@@ -5,6 +5,7 @@
          racket/list
          racket/contract
          racket/stxparam
+         "control.rkt"
          "unify.rkt")
 
 ;Dorai Sitaram
@@ -21,22 +22,27 @@
 (define-syntax %or
   (syntax-rules ()
     ((%or g ...)
-     (lambda (__fk)
-       (let/racklog-sk __sk
-         (let/racklog-fk (__fk __fk)
-           (__sk ((logic-var-val* g) __fk)))
+     (lambda (__sk)
+       (lambda (__fk)
+         (let/racklog-fk __fk
+           (((logic-var-val* g) __sk) __fk))
          ...
-         (__fk 'fail))))))
+         (__fk))))))
 
 (define-syntax %and
   (syntax-rules ()
-    ((%and g ...)
-     (lambda (__fk)
-       (let* ((__fk ((logic-var-val* g) __fk))
-              ...)
-         __fk)))))
+    ((%and)
+     (lambda (__sk)
+       (lambda (__fk)
+         (__sk __fk))))
+    ((%and g gs ...)
+     (lambda (__sk)
+       (lambda (__fk)
+         (((logic-var-val* g)
+           ((%and gs ...) __sk))
+          __fk))))))
 
-(define (%apply pred args)
+(define ((%apply pred args) sk)
   (lambda (fk)
     (let ([pred-v (if (logic-var? pred)
                       (logic-var-val pred)
@@ -46,26 +52,27 @@
                       (cond
                         [(null? v) v]
                         [(pair? v) (cons (car v) (lv->list (cdr v)))]
-                        [else (fk 'fail)])))])
+                        [else (fk)])))])
       (if (and (procedure? pred-v) (procedure-arity-includes? pred-v (length args-v)))
-          ((apply pred-v args-v) fk)
-          (fk 'fail)))))
+          (((apply pred-v args-v) sk) fk)
+          (fk)))))
 
 (define (%andmap pred lst . rest)
   (define lsts (cons lst rest))
-  (lambda (fk)
-    (let/racklog-sk sk
+  (lambda (sk)
+    (lambda (fk)
       ; Base case (all lists empty)
-      (let/racklog-fk (fk fk)
-        (sk (foldl (lambda (lst fk) ((%= lst '()) fk)) fk lsts)))
+      (let/racklog-fk fk
+        ((foldr (lambda (lst sk) ((%= lst '()) sk)) sk lsts) fk))
       ; Call and recurse
-      (let/racklog-fk (fk fk)
-        (sk (let ([heads (map (lambda (lst) (_)) lsts)]
-                  [tails (map (lambda (lst) (_)) lsts)])
-              (let* ([fk (foldl (lambda (lst h t fk) ((%= lst (cons h t)) fk)) fk lsts heads tails)]
-                     [fk ((%apply pred heads) fk)])
-                ((apply %andmap pred tails) fk)))))
-      (fk 'fail))))
+      (let/racklog-fk fk
+        (let ([heads (map (lambda (lst) (_)) lsts)]
+              [tails (map (lambda (lst) (_)) lsts)])
+          (let* ([sk ((apply %andmap pred tails) sk)]
+                 [sk ((%apply pred heads) sk)]
+                 [sk (foldr (lambda (lst h t sk) ((%= lst (cons h t)) sk)) sk lsts heads tails)])
+            (sk fk))))
+      (fk))))
 
 (define-syntax-parameter !
   (λ (stx) (raise-syntax-error '! "May only be used syntactically inside %rel or %cut-delimiter expression." stx)))
@@ -73,27 +80,25 @@
 (define-syntax %cut-delimiter
   (syntax-rules ()
     ((%cut-delimiter g)
-     (lambda (__fk)
-       (let ((this-! (lambda (__fk2)
-                       (lambda (msg)
-                         ; Unwind any bindings in the body
-                         (unless (equal? __fk2 __fk) (__fk2 __fk))
-                         ; Pass on the message, skipping the body
-                         (unless (equal? __fk msg) (__fk msg))))))
-         (syntax-parameterize 
-          ([! (make-rename-transformer #'this-!)])
-          ((logic-var-val* g) __fk)))))))
+     (lambda (__sk)
+       (lambda (__fk)
+         (let ([this-! (lambda (__sk2)
+                         (lambda (__fk2)
+                           (__sk2 __fk)))])
+           (syntax-parameterize
+               ([! (make-rename-transformer #'this-!)])
+             (((logic-var-val* g) __sk) __fk))))))))
 
 (struct relation (clauses)
   #:property prop:procedure
   (lambda (rel . __fmls)
     (%cut-delimiter
-      (lambda (__fk)
-        (let/racklog-sk __sk
+      (lambda (__sk)
+        (lambda (__fk)
           (for ([clause (in-list (relation-clauses rel))])
-            (let/racklog-fk (fail-clause __fk)
-              (__sk ((clause __fmls !) fail-clause))))
-          (__fk 'fail))))))
+            (let/racklog-fk fail-clause
+              (((clause __fmls !) __sk) fail-clause)))
+          (__fk))))))
 
 (define-syntax %rel
   (syntax-rules ()
@@ -107,11 +112,11 @@
                    subgoal ...))))
        ...)))))
 
-(define %fail
-  (lambda (fk) (fk 'fail)))
+(define ((%fail sk) fk)
+  (fk))
 
-(define %true
-  (lambda (fk) fk))
+(define ((%true sk) fk)
+  (sk fk))
 
 (define-for-syntax orig-insp (variable-reference->module-declaration-inspector
                               (#%variable-reference)))
@@ -123,8 +128,9 @@
                         (local-expand #'e 'expression empty)
                         orig-insp)])
        (syntax/loc stx
-         (lambda (__fk)
-           ((%= v (%is/fk fe __fk)) __fk))))]))
+         (lambda (__sk)
+           (lambda (__fk)
+             (((%= v (%is/fk fe __fk)) __sk) __fk)))))]))
 (define-syntax (%is/fk stx)
   (kernel-syntax-case stx #f
     [(_ (#%plain-lambda fmls e ...) fk)
@@ -165,18 +171,9 @@
     [(_ x fk)
      (syntax/loc stx
        (if (and (logic-var? x) (unbound-logic-var? x))
-           (fk 'fail) (logic-var-val* x)))]
+           (fk) (logic-var-val* x)))]
     
     ))
-
-#;(define-syntax %is/fk
-  (syntax-rules (quote)
-    ((%is/fk (quote x) fk) (quote x))
-    ((%is/fk (x ...) fk)
-     ((%is/fk x fk) ...))
-    ((%is/fk x fk)
-     (if (and (logic-var? x) (unbound-logic-var? x))
-         (fk 'fail) (logic-var-val* x)))))
 
 (define ((make-binary-arithmetic-relation f) x y)
   (%and (%is #t (number? x))
@@ -190,52 +187,46 @@
 (define %<= (make-binary-arithmetic-relation <=))
 (define %=/= (make-binary-arithmetic-relation (compose not =)))
 
-(define (%constant x)
-  (lambda (fk)
-    (if (constant? x) fk (fk 'fail))))
+(define (((%constant x) sk) fk)
+  (if (constant? x) (sk fk) (fk)))
 
-(define (%compound x)
-  (lambda (fk)
-    (if (is-compound? x) fk (fk 'fail))))
+(define (((%compound x) sk) fk)
+  (if (is-compound? x) (sk fk) (fk)))
 
-(define (%var x)
-  (lambda (fk) (if (var? x) fk (fk 'fail))))
+(define (((%var x) sk) fk)
+  (if (var? x) (sk fk) (fk)))
 
-(define (%nonvar x)
-  (lambda (fk) (if (var? x) (fk 'fail) fk)))
+(define (((%nonvar x) sk) fk)
+  (if (var? x) (fk) (sk fk)))
 
 (define ((make-negation p) . args) 
   ;basically inlined cut-fail
-  (lambda (fk)
-    (if (let/racklog-sk k
-          ((apply p args) (make-racklog-fk (lambda (d) (k #f)))))
-        (fk 'fail)
-        fk)))
+  (lambda (sk)
+    (lambda (fk)
+      (((apply p args)
+        (lambda (fk2) (fk)))
+       (lambda () (sk fk))))))
 
 (define %/=
   (make-negation %=))
 
-(define (%== x y)
-  (lambda (fk) (if (ident? x y) fk (fk 'fail))))
+(define (((%== x y) sk) fk)
+  (if (ident? x y) (sk fk) (fk)))
 
-(define (%/== x y)
-  (lambda (fk) (if (ident? x y) (fk 'fail) fk)))
+(define %/==
+  (make-negation %==))
 
-(define (%freeze s f)
-  (lambda (fk)
-    ((%= (freeze s) f) fk)))
+(define (((%freeze s f) sk) fk)
+  (((%= (freeze s) f) sk) fk))
 
-(define (%melt f s)
-  (lambda (fk)
-    ((%= (melt f) s) fk)))
+(define (((%melt f s) sk) fk)
+  (((%= (melt f) s) sk) fk))
 
-(define (%melt-new f s)
-  (lambda (fk)
-    ((%= (melt-new f) s) fk)))
+(define (((%melt-new f s) sk) fk)
+  (((%= (melt-new f) s) sk) fk))
 
-(define (%copy s c)
-  (lambda (fk)
-    ((%= (copy s) c) fk)))
+(define (((%copy s c) sk) fk)
+  (((%= (copy s) c) sk) fk))
 
 (define (%not g)
   (%if-then-else g %fail %true))
@@ -281,16 +272,16 @@
     (make-bag-of-aux kons fvv lv goal bag)))
 
 (define (make-bag-of-aux kons fvv lv goal bag)
-  (lambda (fk)
-    (let/racklog-sk sk
+  (lambda (sk)
+    (lambda (fk)
       (let ((lv2 (cons fvv lv)))
-        (let* ((acc '())
-               (fk-final
-                (lambda (d)
-                  (sk ((separate-bags fvv bag acc) fk))))
-               (fk-retry (goal fk-final)))
-          (set! acc (kons (logic-var-val* lv2) acc))
-          (fk-retry 'retry))))))
+        (define acc '())
+        ((goal
+          (lambda (fk)
+            (set! acc (kons (logic-var-val* lv2) acc))
+            (fk)))
+         (lambda ()
+           (((separate-bags fvv bag acc) sk) fk)))))))
 
 (define (separate-bags fvv bag acc)
   (let ((bags (let loop ((acc acc)
@@ -329,22 +320,22 @@
     ((%which (v ...) g)
      (with-racklog-prompt
        (%let (v ...)
-         (set-box! *more-fk*
-                   ((logic-var-val* g)
-                    (make-racklog-fk
-                     (lambda (d)
-                       (set-box! *more-fk* #f)
-                       (abort-to-racklog-prompt #f)))))
-         (abort-to-racklog-prompt
-          (list (cons 'v (logic-var-val* v))
-                ...)))))
+         (((logic-var-val* g)
+           (lambda (fk)
+             (set-box! *more-fk* fk)
+             (abort-to-racklog-prompt
+              (list (cons 'v (logic-var-val* v))
+                    ...))))
+          (lambda ()
+            (set-box! *more-fk* #f)
+            (abort-to-racklog-prompt #f))))))
     [(%which (v ...) g ...)
      (%which (v ...) (%and g ...))]))
 
 (define (%more)
   (with-racklog-prompt
     (if (unbox *more-fk*)
-        ((unbox *more-fk*) 'more)
+        ((unbox *more-fk*))
         #f)))
 
 (define-syntax %find-all
@@ -359,22 +350,14 @@
       (list* a (%more-list))
       empty))
 
-(define racklog-prompt-tag (make-continuation-prompt-tag 'racklog))
 (define (abort-to-racklog-prompt a)
   (abort-current-continuation racklog-prompt-tag (λ () a)))
 (define-syntax-rule (with-racklog-prompt e ...)
   (call-with-continuation-prompt (λ () e ...) racklog-prompt-tag))
 (define-syntax-rule (let/racklog-cc k e ...)
   (call-with-current-continuation (λ (k) e ...) racklog-prompt-tag))
-(define-syntax-rule (let/racklog-sk k e ...)
+(define-syntax-rule (let/racklog-fk k e ...)
   (let/racklog-cc k e ...))
-(define (make-racklog-fk fk [uk #f])
-  (λ (msg)
-    (if (procedure? msg)
-        (when uk (unless (equal? uk msg) (uk msg))) ; unwind
-        (fk 'fail))))
-(define-syntax-rule (let/racklog-fk (k uk) e ...)
-  (let/racklog-cc fk (let ([k (make-racklog-fk fk uk)]) e ...)))
 
 (define (%member x y)
   (%let (xs z zs)
@@ -400,10 +383,11 @@
         (())
         (() (%repeat))))
 
-(define fk? ((or/c symbol? procedure?) . -> . any))
+(define fk? (-> none/c))
+(define sk? (fk? . -> . none/c))
 (define goal/c 
   (or/c goal-with-free-vars?
-        (fk? . -> . fk?)))
+        (sk? . -> . (fk? . -> . none/c))))
 (define relation/c
   (->* () () #:rest (listof unifiable?) goal/c))
 


### PR DESCRIPTION
I realize this is quite a big change, so no rush! (Criticism welcome, of course)

### Overview

Fundamentally, this changes logic vars from mutable holders into continuation mark keys. Values bound through unification are associated with these marks, so unwinding is simply a case of jumping back up the stack.

This is achieved by implementing a `let/logic-var` form which adds the mark, and so instead of indicating success by _returning_, goals must now call a success continuation, in much the same way as they call the existing failure continuation.

In other words, the type of goals has changed from `FK -> FK` to `SK -> FK -> (nothing)`

This (IMHO) makes things quite a bit simpler by doing away with the explicit "unwind-trail" logic, and expressing both success and failure in continuation-passing style (as opposed to only failure-by-CPS previously).

### Motivation

 - Simpler and easier-to-follow flow
 - Allows supporting fun stuff like delayed goals (which are needed for constraint solving, which is something I'd find very useful)
 - Feels more "Rackety" to avoid mutation

### Observations

(Assuming I've understood the underlying mechanisms correctly)
 - Memory usage should be roughly the same as building up a chain of "unwind" FKs
 - Unwinding is now simply a case of invoking a failure continuation, which should be much faster
 - Logical variable references now involve a continuation mark lookup, which should be a little slower
 - Measurements of the test suite and my application indicate performance is about the same
 - User-facing behavior should be unchanged
 - Test suites still pass (of course)